### PR TITLE
Fix empty properties error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,10 @@ function serialize(resource, schema, options = {}) {
   const decorated = decorate ? decorate(resource) : resource;
   const serialized = {};
 
+  if (!schema.properties) {
+    return toJSON(resource);
+  }
+
   Object.keys(schema.properties).forEach((propertyName) => {
     const propertyDef = schema.properties[propertyName];
     let value = decorated[propertyName];

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -92,7 +92,7 @@ describe('Serializers', () => {
       .toEqual({ a: 'x', modelsB: [{ b: 777, c: true }, { b: 777, c: true }] });
   });
 
-  it('Serialize object with empry properties', () => {
+  it('Serialize schema with empry properties', () => {
     const schema = {
       type: 'object',
     };

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -91,4 +91,16 @@ describe('Serializers', () => {
     expect(serialize(instanceA, schema))
       .toEqual({ a: 'x', modelsB: [{ b: 777, c: true }, { b: 777, c: true }] });
   });
+
+  it('Serialize object with empry properties', () => {
+    const schema = {
+      type: 'object',
+    };
+    const row = {
+      some_field: 1,
+    };
+    const data = [row];
+    const result = serialize(data, schema);
+    expect(result[0]).toEqual(row);
+  });
 });


### PR DESCRIPTION
Tinyspec для деклараций типа 
some_field: o
генерит json schema без properties, библиотека падает с ошибкой в таких случаях 